### PR TITLE
feat: Add 'My Videos' page for local video playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,36 @@
             </div>
         </div>
 
+        <!-- My Videos View -->
+        <div id="my-videos-view" class="content-section hidden">
+            <div class="max-w-7xl mx-auto">
+                <header class="mb-4 text-center">
+                    <h1 class="text-3xl sm:text-4xl font-bold text-white">マイ動画</h1>
+                    <p class="text-gray-400 mt-2">ローカルの動画ファイルを再生します。スペースで再生/停止、矢印キーで1秒シーク。</p>
+                </header>
+                <div class="mb-4 flex gap-2">
+                    <input type="file" id="my-video-input" class="form-input w-full bg-gray-700 border-gray-600 rounded-md text-white px-3 py-2" accept="video/*">
+                    <button id="show-my-video-history-button" class="bg-gray-600 hover:bg-gray-500 text-white font-bold px-4 py-2 rounded-md flex-shrink-0">履歴</button>
+                </div>
+                <div class="flex gap-4" style="height: 70vh;">
+                    <div class="w-3/4 player-container">
+                        <video id="my-video-player" class="w-full h-full" controls></video>
+                    </div>
+                    <div class="w-1/4 flex flex-col memo-area">
+                        <div class="flex justify-between items-center p-2 border-b border-gray-700">
+                            <h3 class="text-lg font-semibold">メモ</h3>
+                            <button id="clear-my-video-memos-button" class="text-xs text-red-400 hover:text-red-300">全削除</button>
+                        </div>
+                        <div id="my-video-memo-display" class="flex-grow overflow-y-auto p-2 bg-gray-800"></div>
+                        <div class="flex gap-2 p-2 bg-gray-800 border-t border-gray-700">
+                            <textarea id="my-video-memo-input" rows="2" placeholder="タイムスタンプ付きでメモを追加..." class="form-textarea w-full bg-gray-700 border-gray-600 rounded-md text-white px-3 py-1 text-sm"></textarea>
+                            <button id="add-my-video-memo-button" class="bg-blue-600 hover:bg-blue-500 text-white font-bold px-3 rounded-md text-sm">追加</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Settings Page View -->
         <div id="settings-page-view" class="content-section hidden">
             <div class="max-w-7xl mx-auto">

--- a/style.css
+++ b/style.css
@@ -92,13 +92,31 @@ input[type="color"]::-moz-color-swatch {
     background: #000;
 }
 
-.player-container iframe {
+.player-container iframe,
+.player-container video {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
+    background-color: #000; /* Add black background for video */
 }
+
+/* Style for file input button */
+input[type="file"]::file-selector-button {
+    background-color: #4a5568; /* bg-gray-600 */
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+input[type="file"]::file-selector-button:hover {
+    background-color: #2d3748; /* bg-gray-700 */
+}
+
 
 .memo-area {
     border: 1px solid #4b5563; /* border-gray-600 */


### PR DESCRIPTION
This commit introduces a new "My Videos" page, allowing users to upload and play local video files.

Key features include:
- A new "My Videos" view accessible from the sidebar.
- A file input to select local video files for playback in an HTML5 video player.
- Duplication of the existing YouTube player's functionality, such as timestamped memos and keyboard controls (space for play/pause, arrow keys for seeking).
- Separate local storage for "My Videos" memos and playback history to avoid conflicts with the YouTube player's data.
- An updated history modal that can display history for either YouTube videos or local videos.
- Integration with the settings export/import feature to include the new data.