### PR TITLE
feat: Implement editable data table for combo history

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,9 +65,22 @@
             <div class="max-w-7xl mx-auto">
                 <header class="mb-4 text-center">
                     <h1 class="text-3xl sm:text-4xl font-bold text-white">コンボ履歴</h1>
-                    <p class="text-gray-400 mt-2">カードを選択して <kbd class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">↑</kbd> <kbd class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">↓</kbd> で移動、<kbd class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">Ctrl+C</kbd>でコピー、<kbd class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">Ctrl+Del</kbd>で削除</p>
+                    <p class="text-gray-400 mt-2">ここでは保存したコンボを編集、管理できます。<kbd class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">↑</kbd> <kbd class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">↓</kbd> で行を選択し、アクションを実行します。</p>
                 </header>
-                <div id="saved-combos-container" class="space-y-4"></div>
+                <div id="history-table-container" class="overflow-x-auto bg-gray-800 rounded-lg border border-gray-700">
+                    <table id="history-table" class="w-full text-sm text-left text-gray-300">
+                        <thead class="text-xs text-gray-400 uppercase bg-gray-700">
+                            <tr>
+                                <th scope="col" class="px-6 py-3 w-6/12">コンボ</th>
+                                <th scope="col" class="px-6 py-3 w-3/12">最終更新日時</th>
+                                <th scope="col" class="px-6 py-3 w-3/12 text-center">アクション</th>
+                            </tr>
+                        </thead>
+                        <tbody id="history-table-body">
+                            <!-- Rows will be injected by JavaScript -->
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -64,23 +64,45 @@ input[type="color"]::-moz-color-swatch {
     display: none;
 }
 
-/* Saved Combo History */
-.saved-combo-card {
+/* History Table */
+#history-table tbody tr {
+    transition: background-color 0.15s ease-in-out;
+    border-bottom: 1px solid #374151; /* border-gray-700 */
+}
+
+#history-table tbody tr:last-of-type {
+    border-bottom: none;
+}
+
+#history-table tbody tr:hover {
+    background-color: #374151; /* bg-gray-700 */
+}
+
+#history-table tbody tr.selected-row,
+#history-table tbody tr.selected-row:hover {
+    background-color: #2563eb; /* bg-blue-600 */
+    color: #ffffff;
+}
+
+#history-table .action-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    visibility: hidden; /* Hide buttons by default */
+}
+
+#history-table tr:hover .action-buttons,
+#history-table tr.selected-row .action-buttons {
+    visibility: visible; /* Show on hover or when selected */
+}
+
+#history-table .history-edit-input {
+    width: 100%;
     background-color: #1f2937; /* bg-gray-800 */
+    color: #d1d5db; /* text-gray-300 */
     border: 1px solid #4b5563; /* border-gray-600 */
-    border-radius: 0.5rem; /* rounded-lg */
-    padding: 1rem;
-    cursor: pointer;
-    transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.saved-combo-card:hover {
-    border-color: #6b7280; /* border-gray-500 */
-}
-
-.selected-card {
-    border-color: #3b82f6; /* border-blue-500 */
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.4);
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.5rem;
 }
 
 /* YouTube Player */


### PR DESCRIPTION
This commit refactors the combo history page from a card-based layout to an editable data table, as requested.

Key changes:
- Replaced the div-based history container with a semantic HTML table in `index.html`.
- Updated `style.css` to style the new table, including hover and selection states, and removed the old card styles.
- Significantly refactored the history-related functions in `script.js`:
  - `renderSavedCombos` now builds table rows with action buttons.
  - Added a new `toggleHistoryItemEdit` function to handle inline editing of combos.
  - Updated `handleHistoryKeyDown` to support keyboard navigation (Arrow keys, F2 for edit, Ctrl+C, Ctrl+Del) on the new table.
  - The data object for saved combos is updated to include `comboPlainText` for easier editing, while retaining `comboHTML` for rich display.